### PR TITLE
Add OpenStreetMap using react-leaflet

### DIFF
--- a/taxi-frontend/package-lock.json
+++ b/taxi-frontend/package-lock.json
@@ -12,11 +12,14 @@
         "@emotion/styled": "^11.11.0",
         "@mui/icons-material": "^5.14.14",
         "@mui/material": "^5.14.14",
+        "leaflet": "^1.9.4",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-leaflet": "^4.2.1",
         "react-router-dom": "^6.17.0"
       },
       "devDependencies": {
+        "@types/leaflet": "^1.9.7",
         "@types/react": "^18.2.15",
         "@types/react-dom": "^18.2.7",
         "@typescript-eslint/eslint-plugin": "^6.0.0",
@@ -1389,6 +1392,16 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
+    "node_modules/@react-leaflet/core": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-2.1.0.tgz",
+      "integrity": "sha512-Qk7Pfu8BSarKGqILj4x7bCSZ1pjuAPZ+qmRwH5S7mDS91VSbVVsJSrW4qA+GPrro8t69gFYVMWb1Zc4yFmPiVg==",
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
     "node_modules/@remix-run/router": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.10.0.tgz",
@@ -1438,11 +1451,26 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.12",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.12.tgz",
+      "integrity": "sha512-uK2z1ZHJyC0nQRbuovXFt4mzXDwf27vQeUWNhfKGwRcWW429GOhP8HxUHlM6TLH4bzmlv/HlEjpvJh3JfmGsAA==",
+      "dev": true
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.13",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.13.tgz",
       "integrity": "sha512-RbSSoHliUbnXj3ny0CNFOoxrIDV6SUGyStHsvDqosw6CkdPV8TtWGlfecuK4ToyMEAql6pzNxgCFKanovUzlgQ==",
       "dev": true
+    },
+    "node_modules/@types/leaflet": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.7.tgz",
+      "integrity": "sha512-FOfKB1ALYUDnXkH7LfTFreWiZr9R7GErqGP+8lYQGWr2GFq5+jy3Ih0M7e9j41cvRN65kLALJ4dc43yZwyl/6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/geojson": "*"
+      }
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.1",
@@ -3583,6 +3611,11 @@
         "json-buffer": "3.0.1"
       }
     },
+    "node_modules/leaflet": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA=="
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -4077,6 +4110,19 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/react-leaflet": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-4.2.1.tgz",
+      "integrity": "sha512-p9chkvhcKrWn/H/1FFeVSqLdReGwn2qmiobOQGO3BifX+/vV/39qhY8dGqbdcPh1e6jxh/QHriLXr7a4eLFK4Q==",
+      "dependencies": {
+        "@react-leaflet/core": "^2.1.0"
+      },
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.14.0",

--- a/taxi-frontend/package.json
+++ b/taxi-frontend/package.json
@@ -15,11 +15,14 @@
     "@emotion/styled": "^11.11.0",
     "@mui/icons-material": "^5.14.14",
     "@mui/material": "^5.14.14",
+    "leaflet": "^1.9.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-leaflet": "^4.2.1",
     "react-router-dom": "^6.17.0"
   },
   "devDependencies": {
+    "@types/leaflet": "^1.9.7",
     "@types/react": "^18.2.15",
     "@types/react-dom": "^18.2.7",
     "@typescript-eslint/eslint-plugin": "^6.0.0",

--- a/taxi-frontend/src/App.css
+++ b/taxi-frontend/src/App.css
@@ -1,42 +1,8 @@
 #root {
-  max-width: 1280px;
+  width: 100%;
+  height: 100vh;
   margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
-}
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
-}
-
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
-}
-
-.card {
-  padding: 2em;
-}
-
-.read-the-docs {
-  color: #888;
+  display: flex;
+  flex-direction: column;
 }

--- a/taxi-frontend/src/App.tsx
+++ b/taxi-frontend/src/App.tsx
@@ -3,17 +3,20 @@ import Navigation from "./components/navigation/Navigation.tsx"
 import { BrowserRouter, Route, Routes } from "react-router-dom"
 import { Link } from "./components/navigation/navigationTabs.ts"
 import { Drivers, Home, Map, Taxi } from "./pages"
+import { Box } from "@mui/material"
 
 function App() {
   return (
     <BrowserRouter>
       <Navigation />
-      <Routes>
-        <Route path={Link.HOME} element={<Home />} />
-        <Route path={Link.TAXI} element={<Taxi />} />
-        <Route path={Link.MAP} element={<Map />} />
-        <Route path={Link.DRIVERS} element={<Drivers />} />
-      </Routes>
+      <Box flexGrow={1}>
+        <Routes>
+          <Route path={Link.HOME} element={<Home />} />
+          <Route path={Link.TAXI} element={<Taxi />} />
+          <Route path={Link.MAP} element={<Map />} />
+          <Route path={Link.DRIVERS} element={<Drivers />} />
+        </Routes>
+      </Box>
     </BrowserRouter>
   )
 }

--- a/taxi-frontend/src/components/map/LeafletMap.css
+++ b/taxi-frontend/src/components/map/LeafletMap.css
@@ -1,0 +1,4 @@
+.leaflet-container {
+  height: 100%;
+  width: 100%;
+}

--- a/taxi-frontend/src/components/map/LeafletMap.tsx
+++ b/taxi-frontend/src/components/map/LeafletMap.tsx
@@ -1,0 +1,19 @@
+import { MapContainer, TileLayer } from "react-leaflet"
+import { LatLngExpression } from "leaflet"
+import "./LeafletMap.css"
+import "leaflet/dist/leaflet.css"
+
+const DEFAULT_COORDINATES: LatLngExpression = [53.133298, 23.131781]
+
+function LeafletMap() {
+  return (
+    <MapContainer center={DEFAULT_COORDINATES} zoom={12} scrollWheelZoom={true}>
+      <TileLayer
+        attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+      />
+    </MapContainer>
+  )
+}
+
+export default LeafletMap

--- a/taxi-frontend/src/components/navigation/Navigation.tsx
+++ b/taxi-frontend/src/components/navigation/Navigation.tsx
@@ -3,21 +3,28 @@ import { AppBar, Button, IconButton, Toolbar, Typography } from "@mui/material"
 import MenuIcon from "@mui/icons-material/Menu"
 import { navigationTabs } from "./navigationTabs.ts"
 import { Link } from "react-router-dom"
+import { styled } from "@mui/material"
+
+const Offset = styled("div")(({ theme }) => theme.mixins.toolbar)
+
 const Navigation: FC = () => {
   return (
-    <AppBar>
-      <Toolbar>
-        <IconButton edge="start" color="inherit" aria-label="menu">
-          <MenuIcon />
-        </IconButton>
-        <Typography variant="h6">Taxi</Typography>
-        {navigationTabs.map(({ name, link }) => (
-          <Button component={Link} to={link} color="inherit">
-            {name}
-          </Button>
-        ))}
-      </Toolbar>
-    </AppBar>
+    <>
+      <AppBar>
+        <Toolbar>
+          <IconButton edge="start" color="inherit" aria-label="menu">
+            <MenuIcon />
+          </IconButton>
+          <Typography variant="h6">Taxi</Typography>
+          {navigationTabs.map(({ name, link }) => (
+            <Button key={name} component={Link} to={link} color="inherit">
+              {name}
+            </Button>
+          ))}
+        </Toolbar>
+      </AppBar>
+      <Offset />
+    </>
   )
 }
 

--- a/taxi-frontend/src/index.css
+++ b/taxi-frontend/src/index.css
@@ -14,56 +14,8 @@
   -webkit-text-size-adjust: 100%;
 }
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
-}
-
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
-}
-
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
-}
-
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
 }

--- a/taxi-frontend/src/pages/map/Map.tsx
+++ b/taxi-frontend/src/pages/map/Map.tsx
@@ -1,7 +1,15 @@
 import { FC } from "react"
+import LeafletMap from "../../components/map/LeafletMap"
+import Grid from "@mui/material/Grid/Grid"
 
 const Map: FC = () => {
-  return "Map"
+  return (
+    <Grid container height={"100%"}>
+      <Grid item xs={12}>
+        <LeafletMap />
+      </Grid>
+    </Grid>
+  )
 }
 
 export default Map


### PR DESCRIPTION
- Added OpenStreetMap using Leaflet/react-leaflet
- The map is currently rendered fullscreen under `/map` route
- Fixed content appearing under navigation bar by placing an empty `Toolbar` directly under (docs: https://mui.com/material-ui/react-app-bar/#fixed-placement)
- Removed unused/unnecessary default CSS
- Added wrapper `Box` for content in `App` to make the navigation bar + content combined have `min-height: 100vh`.